### PR TITLE
[WIP] Run CI Builds on CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # README
 
-This is a sample infrastructure repository using the [vagrant-toplevel-cookbooks](https://github.com/tknerr/vagrant-toplevel-cookbooks) plugin to resolve the top-level cookbook dependencies for each of the `Vagrantfile`'s VMs in isolation. 
+[![Circle CI](https://circleci.com/gh/tknerr/sample-infrastructure-repo/tree/master.svg?style=shield)](https://circleci.com/gh/tknerr/sample-infrastructure-repo/tree/master)
+
+This is a sample infrastructure repository using the [vagrant-toplevel-cookbooks](https://github.com/tknerr/vagrant-toplevel-cookbooks) plugin to resolve the top-level cookbook dependencies for each of the `Vagrantfile`'s VMs in isolation.
 
 The aim is to get the whole infrastructure up and running with a single `vagrant up`, with all the cookbook dependency resolution happening under the hood.
 
 # TODO
 
-Other stuff that should be demonstrated here: 
+Other stuff that should be demonstrated here:
 - [ ] encrypted data bags
 - [ ] different providers (e.g. lxc, aws)
 - [ ] Cheffile vs. Berksfile
@@ -23,5 +25,3 @@ Now you can bring up and provision the VMs in the `Vagrantfile` with a single co
 
 	vagrant up app_v1
 	vagrant up app_v2
-
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,10 +20,6 @@ Vagrant::configure("2") do |config|
     override.vm.box = "fgrehm/precise64-lxc"
   end
   config.vm.provider :docker do |docker, override|
-    docker.image = "ubuntu:12.04"
-    docker.has_ssh = true
-  end
-  config.vm.provider :docker do |docker, override|
     docker.image = "tknerr/baseimage-ubuntu:12.04"
     docker.has_ssh = true
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,8 +10,9 @@ Vagrant::configure("2") do |config|
   end
 
   # common baseboxes for all VMs
-  config.vm.box = "chef/ubuntu-12.04-i386"
-
+  config.vm.provider :virtualbox do |vbox, override|
+    override.vm.box = "chef/ubuntu-12.04-i386"
+  end
   config.vm.provider :lxc do |lxc, override|
     override.vm.box = "fgrehm/precise64-lxc"
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,9 @@ Vagrant::configure("2") do |config|
   config.vm.provider :lxc do |lxc, override|
     override.vm.box = "fgrehm/precise64-lxc"
   end
+  config.vm.provider :docker do |docker, override|
+    docker.image = "ubuntu:12.04"
+  end
 
   #
   # app provisioned with v0.2.0 of the top-level cookbook

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,9 @@ Vagrant::configure("2") do |config|
     config.berkshelf.enabled = false
   end
   # use machine scope caching for multi-vm setups
-  config.cache.scope = :machine
+  if Vagrant.has_plugin? "cachier"
+    config.cache.scope = :machine
+  end
 
   # common baseboxes for all VMs
   config.vm.provider :virtualbox do |vbox, override|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,7 @@ Vagrant::configure("2") do |config|
   end
   config.vm.provider :docker do |docker, override|
     docker.image = "ubuntu:12.04"
+    docker.has_ssh = true
   end
 
   #

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,9 @@ Vagrant::configure("2") do |config|
   config.omnibus.chef_version = "12.0.3"
 
   # disable vagrant-berkshelf
-  config.berkshelf.enabled = false
+  if Vagrant.has_plugin? "berkshelf"
+    config.berkshelf.enabled = false
+  end
 
   # common baseboxes for all VMs
   config.vm.box = "chef/ubuntu-12.04-i386"

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,21 @@
+machine:
+  services:
+    - docker
+  ruby:
+    version: 2.1.3
+  environment:
+    VAGRANT_DEFAULT_PROVIDER: docker
+
+dependencies:
+  pre:
+    - wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2_x86_64.deb
+    - sudo dpkg -i vagrant_1.7.2_x86_64.deb
+    - vagrant plugin install vagrant-toplevel-cookbooks --plugin-version 0.2.3
+    - vagrant plugin install vagrant-omnibus --plugin-version 1.4.1
+
+test:
+  override:
+    - vagrant up app_v1
+    - vagrant ssh app_v1 -c 'pwd'
+    - vagrant provision app_v1
+    - vagrant destroy app_v1 -f

--- a/circle.yml
+++ b/circle.yml
@@ -9,14 +9,18 @@ machine:
 dependencies:
   cache_directories:
     - ~/.vagrant.d
+    - ~/.chefdk
   pre:
     - wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2_x86_64.deb
     - sudo dpkg -i vagrant_1.7.2_x86_64.deb
     - vagrant plugin install vagrant-toplevel-cookbooks
     - vagrant plugin install vagrant-omnibus
+    - wget https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chefdk_0.6.0-1_amd64.deb
+    - sudo dpkg -i chefdk_0.6.0-1_amd64.deb
 
 test:
   override:
+    - berks -v
     - vagrant up app_v1
     - vagrant ssh app_v1 -c 'pwd'
     - vagrant provision app_v1

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
     version: 2.1.3
   environment:
     VAGRANT_DEFAULT_PROVIDER: docker
+    VAGRANT_LOG: DEBUG
 
 dependencies:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -24,4 +24,3 @@ test:
     - vagrant up app_v1
     - vagrant ssh app_v1 -c 'pwd'
     - vagrant provision app_v1
-    - vagrant destroy app_v1 -f

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,6 @@ machine:
     version: 2.1.5
   environment:
     VAGRANT_DEFAULT_PROVIDER: docker
-    VAGRANT_LOG: DEBUG
 
 dependencies:
   cache_directories:

--- a/circle.yml
+++ b/circle.yml
@@ -22,5 +22,6 @@ test:
   override:
     - berks -v
     - vagrant up app_v1
+    - wget -qO- http://localhost:8080/sample.html | grep "Chuck Norris"
     - vagrant ssh app_v1 -c 'pwd'
     - vagrant provision app_v1

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   services:
     - docker
   ruby:
-    version: 2.1.3
+    version: 2.1.5
   environment:
     VAGRANT_DEFAULT_PROVIDER: docker
     VAGRANT_LOG: DEBUG
@@ -11,8 +11,8 @@ dependencies:
   pre:
     - wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2_x86_64.deb
     - sudo dpkg -i vagrant_1.7.2_x86_64.deb
-    - vagrant plugin install vagrant-toplevel-cookbooks --plugin-version 0.2.3
-    - vagrant plugin install vagrant-omnibus --plugin-version 1.4.1
+    - vagrant plugin install vagrant-toplevel-cookbooks
+    - vagrant plugin install vagrant-omnibus
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,8 @@ machine:
     VAGRANT_LOG: DEBUG
 
 dependencies:
+  cache_directories:
+    - ~/.vagrant.d
   pre:
     - wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2_x86_64.deb
     - sudo dpkg -i vagrant_1.7.2_x86_64.deb


### PR DESCRIPTION
First shot, not working yet.

The vagrant vm does not come up yet with the docker provider. And even if, the vagrant docker provider does not support private_networking.

Ideally we would get vagrant-lxc working here. Check fgrehm/vagrant-lxc#339 for progress on this