### PR TITLE
[WIP] Try using plain vagrant-berkshelf instead of vagrant-toplevel-cookbooks

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,13 @@
+source "https://supermarket.chef.io"
+
+group :app_v1 do
+  cookbook "sample-app", github: "tknerr/sample-toplevel-cookbook", tag: "v0.2.0"
+end
+
+group :app_v2 do
+  cookbook "sample-app", github: "tknerr/sample-toplevel-cookbook", tag: "v0.1.2"
+end
+
+group :app_local do
+  cookbook "sample-app", path: "C:/Repos/_github/_cookbooks/sample-toplevel-cookbook"
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant::configure("2") do |config|
   config.omnibus.chef_version = "12.0.3"
 
   # disable vagrant-berkshelf
-  config.berkshelf.enabled = false
+  config.berkshelf.enabled = true
 
   # common baseboxes for all VMs
   config.vm.box = "chef/ubuntu-12.04-i386"
@@ -18,8 +18,8 @@ Vagrant::configure("2") do |config|
   # app provisioned with v0.2.0 of the top-level cookbook
   #
   config.vm.define :'app_v1' do |app_config|
-    app_config.toplevel_cookbook.url = "https://github.com/tknerr/sample-toplevel-cookbook"
-    app_config.toplevel_cookbook.ref = "v0.2.0"
+
+    app_config.berkshelf.only = [ "app_v1" ]
 
     app_config.vm.hostname = "appv1.local"
     app_config.vm.network :private_network, ip: "192.168.40.30", lxc__bridge_name: 'vlxcbr1'
@@ -38,8 +38,7 @@ Vagrant::configure("2") do |config|
   # app provisioned with v0.1.2 of the top-level cookbook
   #
   config.vm.define :'app_v2' do |app_config|
-    app_config.toplevel_cookbook.url = "https://github.com/tknerr/sample-toplevel-cookbook"
-    app_config.toplevel_cookbook.ref = "v0.1.2"
+    app_config.berkshelf.only = [ "app_v2" ]
     app_config.vm.provision :chef_solo do |chef|
       chef.add_recipe "sample-app"
     end
@@ -53,7 +52,8 @@ Vagrant::configure("2") do |config|
     app_config.vm.hostname = "applocal.local"
     app_config.vm.network :private_network, ip: "192.168.40.32"
 
-    app_config.toplevel_cookbook.url = "file:///W:/repo/sample-toplevel-cookbook"
+    app_config.berkshelf.only = [ "app_local" ]
+
     app_config.vm.provision :chef_solo do |chef|
       chef.add_recipe "sample-app"
       chef.data_bags_path = "./data_bags"


### PR DESCRIPTION
This is a try of using vagrant-berkshelf only for resolving multiple disjoint (top level) cookbooks that make up a multi-vm infrastructure. 

If this works this essentially makes the vagrant-toplevel-cookbooks plugin unnecessary.

According to the docs it should work by 

* using the groups feature of berkshelf 
* defining one group per VM
* running `berks vendor --only <group>` for each VM separately

However, I could not get it to work so far (using berkshelf 3.2.3 and vagrant-berkshelf 4.0.2). Problems are:

1. `berks install --only` does not work
2. even if it worked, it seems it would use only a sinlge Berksfile.lock. Not sure how that would work out in a multi-vm setup