### PR TITLE
[WIP] Try using plain vagrant-berkshelf instead of vagrant-toplevel-cookbooks (alternative approach)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant/
+Berksfile.*lock

--- a/Berksfile.app_local
+++ b/Berksfile.app_local
@@ -1,0 +1,3 @@
+source "https://supermarket.chef.io"
+
+cookbook "sample-app", path: "C:/Repos/_github/_cookbooks/sample-toplevel-cookbook"

--- a/Berksfile.app_v1
+++ b/Berksfile.app_v1
@@ -1,0 +1,3 @@
+source "https://supermarket.chef.io"
+
+cookbook "sample-app", github: "tknerr/sample-toplevel-cookbook", tag: "v0.2.0"

--- a/Berksfile.app_v2
+++ b/Berksfile.app_v2
@@ -1,0 +1,3 @@
+source "https://supermarket.chef.io"
+
+cookbook "sample-app", github: "tknerr/sample-toplevel-cookbook", tag: "v0.1.2"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant::configure("2") do |config|
   config.omnibus.chef_version = "12.0.3"
 
   # disable vagrant-berkshelf
-  config.berkshelf.enabled = false
+  config.berkshelf.enabled = true
 
   # common baseboxes for all VMs
   config.vm.box = "chef/ubuntu-12.04-i386"
@@ -18,8 +18,8 @@ Vagrant::configure("2") do |config|
   # app provisioned with v0.2.0 of the top-level cookbook
   #
   config.vm.define :'app_v1' do |app_config|
-    app_config.toplevel_cookbook.url = "https://github.com/tknerr/sample-toplevel-cookbook"
-    app_config.toplevel_cookbook.ref = "v0.2.0"
+
+    app_config.berkshelf.berksfile_path = "Berksfile.app_v1"
 
     app_config.vm.hostname = "appv1.local"
     app_config.vm.network :private_network, ip: "192.168.40.30", lxc__bridge_name: 'vlxcbr1'
@@ -38,8 +38,7 @@ Vagrant::configure("2") do |config|
   # app provisioned with v0.1.2 of the top-level cookbook
   #
   config.vm.define :'app_v2' do |app_config|
-    app_config.toplevel_cookbook.url = "https://github.com/tknerr/sample-toplevel-cookbook"
-    app_config.toplevel_cookbook.ref = "v0.1.2"
+    app_config.berkshelf.berksfile_path = "Berksfile.app_v2"
     app_config.vm.provision :chef_solo do |chef|
       chef.add_recipe "sample-app"
     end
@@ -53,7 +52,8 @@ Vagrant::configure("2") do |config|
     app_config.vm.hostname = "applocal.local"
     app_config.vm.network :private_network, ip: "192.168.40.32"
 
-    app_config.toplevel_cookbook.url = "file:///W:/repo/sample-toplevel-cookbook"
+    app_config.berkshelf.berksfile_path = "Berksfile.app_local"
+
     app_config.vm.provision :chef_solo do |chef|
       chef.add_recipe "sample-app"
       chef.data_bags_path = "./data_bags"


### PR DESCRIPTION
This PR tries to achieve the same as #4, namely replacing the need for vagrant-toplevel-cookbooks by using a plain vagrant-berkshelf solution.

In contrast to #4, the approach here is to use separate Berksfiles per VM rather than a single Berksfile with groups:

 * using `config.berkshelf.path = "Berksfile.<name>"` to define disjoint Berksfiles 
 * defining one Berksfile per VM

It seems to work quite well in the first experiments. Notes:

 * it creates a separate .lock file for each Berksfile -- so there's no potential conflict here as with using the groups feature
 * (!) you need to delete the .lock file when updating the cookbook version via the tag ref. `rm Berksfile.app_v1.lock && vagrant provision app_v1` works :+1: 