### PR TITLE
Use latest Vagrant 1.7.4 and ChefDK 0.7.0 for the CircleCI builds

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,8 +20,7 @@ Vagrant::configure("2") do |config|
     override.vm.box = "fgrehm/precise64-lxc"
   end
   config.vm.provider :docker do |docker, override|
-    docker.image = "tknerr/baseimage-ubuntu:12.04"
-    docker.has_ssh = true
+    override.vm.box = "tknerr/baseimage-ubuntu-12.04"
   end
 
   #

--- a/circle.yml
+++ b/circle.yml
@@ -11,12 +11,12 @@ dependencies:
     - ~/.vagrant.d
     - ~/.chefdk
   pre:
-    - wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2_x86_64.deb
-    - sudo dpkg -i vagrant_1.7.2_x86_64.deb
+    - wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.4_x86_64.deb
+    - sudo dpkg -i vagrant_1.7.4_x86_64.deb
     - vagrant plugin install vagrant-toplevel-cookbooks
     - vagrant plugin install vagrant-omnibus
-    - wget https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chefdk_0.6.0-1_amd64.deb
-    - sudo dpkg -i chefdk_0.6.0-1_amd64.deb
+    - wget https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chefdk_0.7.0-1_amd64.deb
+    - sudo dpkg -i chefdk_0.7.0-1_amd64.deb
 
 test:
   override:


### PR DESCRIPTION
Update to the latest ChefDK 0.7.0 and Vagrant 1.7.4 versions for the CircleCI build.

Also, with Vagrant 1.7.4 we can use docker baseboxes via the standard `config.vm.box` mechanism