### PR TITLE
Update to Vagrant 1.8 / ChefDK 0.13 and fix the CircleCI build

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 Vagrant::configure("2") do |config|
 
   # the Chef version to use
-  config.omnibus.chef_version = "12.4.1"
+  config.omnibus.chef_version = "12.9.41"
   # disable vagrant-berkshelf
   if Vagrant.has_plugin? "berkshelf"
     config.berkshelf.enabled = false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,9 +16,6 @@ Vagrant::configure("2") do |config|
   config.vm.provider :virtualbox do |vbox, override|
     override.vm.box = "bento/ubuntu-12.04"
   end
-  config.vm.provider :lxc do |lxc, override|
-    override.vm.box = "fgrehm/precise64-lxc"
-  end
   config.vm.provider :docker do |docker, override|
     override.vm.box = "tknerr/baseimage-ubuntu-12.04"
   end
@@ -32,7 +29,6 @@ Vagrant::configure("2") do |config|
 
     app_config.vm.hostname = "appv1.local"
     app_config.vm.network :forwarded_port, guest: 80, host: 8080
-    app_config.vm.network :private_network, ip: "172.16.40.30", lxc__bridge_name: 'vlxcbr1'
 
     app_config.vm.provision :chef_solo do |chef|
       chef.add_recipe "sample-app"

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ dependencies:
     - sudo dpkg -i vagrant_1.8.1_x86_64.deb
     - vagrant plugin install vagrant-toplevel-cookbooks
     - vagrant plugin install vagrant-omnibus
-    - wget https://packages.chef.io/stable/ubuntu/12.04/chefdk_0.13.21-1_amd64.deb
+    - wget --no-check-certificate https://packages.chef.io/stable/ubuntu/12.04/chefdk_0.13.21-1_amd64.deb
     - sudo dpkg -i chefdk_0.13.21-1_amd64.deb
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -11,8 +11,8 @@ dependencies:
     - ~/.vagrant.d
     - ~/.chefdk
   pre:
-    - wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.4_x86_64.deb
-    - sudo dpkg -i vagrant_1.7.4_x86_64.deb
+    - wget https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb
+    - sudo dpkg -i vagrant_1.8.1_x86_64.deb
     - vagrant plugin install vagrant-toplevel-cookbooks
     - vagrant plugin install vagrant-omnibus
     - wget https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chefdk_0.7.0-1_amd64.deb

--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,8 @@ dependencies:
     - sudo dpkg -i vagrant_1.8.1_x86_64.deb
     - vagrant plugin install vagrant-toplevel-cookbooks
     - vagrant plugin install vagrant-omnibus
-    - wget https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chefdk_0.7.0-1_amd64.deb
-    - sudo dpkg -i chefdk_0.7.0-1_amd64.deb
+    - wget https://packages.chef.io/stable/ubuntu/12.04/chefdk_0.13.21-1_amd64.deb
+    - sudo dpkg -i chefdk_0.13.21-1_amd64.deb
 
 test:
   override:


### PR DESCRIPTION
This PR 
- updates to Vagrant 1.8.1
- updates to ChefDK 0.13.21
- updates to Chef Client 12.9.41 in Vagrantfile
- removes vagrant-lxc support as it currently breaks locally and is no longer needed anyway
